### PR TITLE
Update `data.aws_region.current` reference to use `id` instead of deprecated `name` attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "secret" {
 }
 
 data "http" "layers" {
-  url = "https://${data.aws_region.current.name}.layers.newrelic-external.com/get-layers"
+  url = "https://${data.aws_region.current.id}.layers.newrelic-external.com/get-layers"
   request_headers = {
     Accept = "application/json"
   }


### PR DESCRIPTION
The `aws_region` data source deprecated the `name` attribute in favor of `id`. This change ensures compatibility with newer versions of the AWS provider.